### PR TITLE
[work in progress] Dedicated shoebox serializer.

### DIFF
--- a/app/instance-initializers/browser/ember-data-fastboot.js
+++ b/app/instance-initializers/browser/ember-data-fastboot.js
@@ -4,7 +4,7 @@ export function initialize(applicationInstance) {
   let dump = shoebox.retrieve('ember-data-store');
   if (!dump) { return; }
   let store = applicationInstance.lookup('service:store');
-  store.pushPayload(dump.records);
+  store.push(dump.records);
 }
 
 export default {

--- a/app/instance-initializers/fastboot/ember-data-fastboot.js
+++ b/app/instance-initializers/fastboot/ember-data-fastboot.js
@@ -2,13 +2,24 @@ export function initialize(applicationInstance) {
   let store = applicationInstance.lookup('service:store');
   let shoebox = applicationInstance.lookup('service:fastboot').get('shoebox');
 
+  let shoeboxSerializer = applicationInstance.lookup('serializer:-shoebox');
+  shoeboxSerializer.set('store', store);
+
   shoebox.put('ember-data-store', {
     get records() {
       return Object.keys(store.typeMaps).map(k => {
         let name = store.typeMaps[k].type.modelName;
         return store.peekAll(name).toArray();
       }).reduce((a,b) => a.concat(b), [])
-        .map(record => record.serialize({ includeId: true}))
+        .filter(record => {
+          // Filter records without an id because they cannot be deserialized.
+          // Call deleteRecord to remove it from any relationships.
+          if (record.get('id')) return true;
+          store.deleteRecord(record);
+          return false;
+        })
+        .map(record => record._createSnapshot())
+        .map(snapshot => shoeboxSerializer.serialize(snapshot, { includeId: true }))
         .reduce((a,b) => { a.data.push(b.data); return a; }, { data: [] });
     }
   });

--- a/app/serializers/-shoebox.js
+++ b/app/serializers/-shoebox.js
@@ -1,0 +1,15 @@
+import DS from 'ember-data';
+
+export default DS.JSONAPISerializer.extend({
+  // store.push expects singular model names in "type":
+  // http://emberjs.com/api/data/classes/DS.Store.html#method_push
+  //
+  // but by default JSONAPISerializer produces plural:
+  // https://github.com/emberjs/data/blob/c6d233b2/addon/serializers/json-api.js#L708-L723
+  // https://github.com/emberjs/data/blob/c6d233b2/addon/serializers/json-api.js#L360-L368
+  //
+  // We override both of these functions to guard against future deprecations:
+  // https://github.com/emberjs/data/blob/c6d233b2/addon/serializers/json-api.js#L598-L612
+  payloadKeyFromModelName(modelName) { return modelName; },
+  payloadTypeFromModelName(modelName) { return modelName; }
+});

--- a/tests/unit/serializers/-shoebox-test.js
+++ b/tests/unit/serializers/-shoebox-test.js
@@ -1,0 +1,15 @@
+import { moduleForModel, test } from 'ember-qunit';
+
+moduleForModel('-shoebox', 'Unit | Serializer |  shoebox', {
+  // Specify the other units that are required for this test.
+  needs: ['serializer:-shoebox']
+});
+
+// Replace this with your real tests.
+test('it serializes records', function(assert) {
+  let record = this.subject();
+
+  let serializedRecord = record.serialize();
+
+  assert.ok(serializedRecord);
+});


### PR DESCRIPTION
@ef4 Here's a potential solution to making this work regardless of an application's particular serialization strategies.

We call `shoeboxSerializer.serialize` instead of `model.serialize`. This guarantees a JSONAPI-compatible(-ish, see my comments) payload.

If you like it let me know and I'll add tests. 😄 

Thanks @pwfisher for the help.
