### PR TITLE
Only push loaded records to the shoebox

### DIFF
--- a/app/instance-initializers/fastboot/ember-data-fastboot.js
+++ b/app/instance-initializers/fastboot/ember-data-fastboot.js
@@ -8,6 +8,7 @@ export function initialize(applicationInstance) {
         let name = store.typeMaps[k].type.modelName;
         return store.peekAll(name).toArray();
       }).reduce((a,b) => a.concat(b), [])
+        .filter(record => record.get('isLoaded'))
         .map(record => record.serialize({ includeId: true}))
         .reduce((a,b) => { a.data.push(b.data); return a; }, { data: [] });
     }


### PR DESCRIPTION
Fixes an issue where records from a relation that haven't been side-loaded are getting pushed to the shoebox with null attributes.