### PR TITLE
Add support to non-jsonapi serializers

### DIFF
--- a/app/instance-initializers/browser/ember-data-fastboot.js
+++ b/app/instance-initializers/browser/ember-data-fastboot.js
@@ -1,10 +1,23 @@
+import Ember from 'ember';
+
 export function initialize(applicationInstance) {
   let shoebox = applicationInstance.lookup('service:fastboot').get('shoebox');
   if (!shoebox) { return; }
   let dump = shoebox.retrieve('ember-data-store');
   if (!dump) { return; }
   let store = applicationInstance.lookup('service:store');
-  store.pushPayload(dump.records);
+
+  Object.keys(dump.records).forEach((modelName) => {
+    let recordsToPush = {};
+    recordsToPush[modelName] = dump.records[modelName];
+    if (Ember.isEmpty(recordsToPush[modelName])) { return; }
+
+    if (Object.keys(recordsToPush[modelName]).includes('data')) {
+      recordsToPush = recordsToPush[modelName];
+    }
+
+    store.pushPayload(modelName, recordsToPush);
+  });
 }
 
 export default {


### PR DESCRIPTION
This PR makes possible to serialize and push model data using its serializer, allowing us to not require JSONAPI serializer.

I'm sure the code could be refactored to make things more clear. Please let me know what should I change to make this land.

Also, I did not wanted to follow the idea from #4 of having a custom serializer because ember data is deprecating `store.serialize` and I wasn't sure if that deprecation would apply to the approach of #4.

This closes #3. 