### PR TITLE
fix issue with latest Ember Data

### DIFF
--- a/app/instance-initializers/fastboot/ember-data-fastboot.js
+++ b/app/instance-initializers/fastboot/ember-data-fastboot.js
@@ -1,14 +1,13 @@
 export function initialize(applicationInstance) {
   let store = applicationInstance.lookup('service:store');
   let shoebox = applicationInstance.lookup('service:fastboot').get('shoebox');
+  const modelNames = applicationInstance.lookup('data-adapter:main').getModelTypes().mapBy('name');
 
   shoebox.put('ember-data-store', {
     get records() {
-      return Object.keys(store.typeMaps).map(k => {
-        let name = store.typeMaps[k].type.modelName;
+      return modelNames.map(name => {
         return store.peekAll(name).toArray();
       }).reduce((a,b) => a.concat(b), [])
-        .filter(record => record.get('isLoaded'))
         .map(record => record.serialize({ includeId: true}))
         .reduce((a,b) => { a.data.push(b.data); return a; }, { data: [] });
     }

--- a/app/instance-initializers/fastboot/ember-data-fastboot.js
+++ b/app/instance-initializers/fastboot/ember-data-fastboot.js
@@ -8,6 +8,7 @@ export function initialize(applicationInstance) {
       return modelNames.map(name => {
         return store.peekAll(name).toArray();
       }).reduce((a,b) => a.concat(b), [])
+        .filter(record => record.get('isLoaded'))
         .map(record => record.serialize({ includeId: true}))
         .reduce((a,b) => { a.data.push(b.data); return a; }, { data: [] });
     }


### PR DESCRIPTION
`store.mapTypes` seems to be undefined on latest Ember Data. This PR introduces different logic to get available model names.