### PR TITLE
Don't load new records

### DIFF
--- a/fastboot/instance-initializers/ember-data-fastboot.js
+++ b/fastboot/instance-initializers/ember-data-fastboot.js
@@ -8,7 +8,7 @@ export function initialize(applicationInstance) {
       return modelNames.map(name => {
         return store.peekAll(name).toArray();
       }).reduce((a,b) => a.concat(b), [])
-        .filter(record => record.get('isLoaded'))
+        .filter(record => record.get('isLoaded') && !record.get('isNew'))
         .map(record => record.serialize({ includeId: true}))
         .reduce((a,b) => { a.data.push(b.data); return a; }, { data: [] });
     }


### PR DESCRIPTION
If the fastboot rendered app puts new records in the store don't load
them in the shoebox. Fixes #8.